### PR TITLE
Automatically insert into any section specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ $ update-draft-release your/repo
 #
 ```
 
+## Options
+
+`--in-top-level`: Insert into top level.
+
+`--in-xxx`: Insert into the section named 'xxx'. E.g. `in-gamma`.
+
+`--at-the-end`: Insert at the end.
+
+`--create-heading`: Create a new heading if the section specified by `--in-xxx` is not found.
+
+`--skip-confirmation`: Skip the confirmation. :trollface:
+
+`--open-url`: Open the url of the release.
+
 ## More
 
 Run `gem uninstall update-draft-release` to uninstall.

--- a/bin/update-draft-release
+++ b/bin/update-draft-release
@@ -18,13 +18,17 @@ options = {}
 # --open-url
 #
 ARGV.each do |arg|
-  case arg
-  when '--at-the-end'
-    options[:insert_at_the_end] = true
-  when '--before-gamma'
-    options[:insert_before] = '## Gamma ##'
-  when '--open-url'
+  case
+  when arg.match(/^--in-[A-z-]+$/)
+    options[:insert_into] = arg[5..-1]
+  when arg == '--open-url'
     options[:open_url_after_update] = true
+  when arg == '--at-the-end'
+    options[:insert_at_the_end] = true
+  when arg == '--create-heading'
+    options[:create_heading] = true
+  when arg == '--skip-confirmation'
+    options[:skip_confirmation] = true
   else
     repo = arg
   end

--- a/bin/update-draft-release
+++ b/bin/update-draft-release
@@ -13,21 +13,26 @@ options = {}
 
 # Acceptable options:
 #
+# --in-gamma
+# --in-assignment
+# --in-top-level
 # --at-the-end
-# --before-gamma
 # --open-url
+# --skip-confirmation
 #
 ARGV.each do |arg|
-  case
-  when arg.match(/^--in-[A-z-]+$/)
-    options[:insert_into] = arg[5..-1]
-  when arg == '--open-url'
-    options[:open_url_after_update] = true
-  when arg == '--at-the-end'
+  case arg
+  when /^--in-(\w+)$/
+    options[:insert_into] = $1.gsub('_', ' ')
+  when '--in-top-level'
+    options[:insert_into] = 'top-level'
+  when '--at-the-end'
     options[:insert_at_the_end] = true
-  when arg == '--create-heading'
+  when '--create-heading'
     options[:create_heading] = true
-  when arg == '--skip-confirmation'
+  when '--open-url'
+    options[:open_url_after_update] = true
+  when '--skip-confirmation'
     options[:skip_confirmation] = true
   else
     repo = arg

--- a/bin/update-draft-release
+++ b/bin/update-draft-release
@@ -17,6 +17,7 @@ options = {}
 # --in-assignment
 # --in-top-level
 # --at-the-end
+# --create-heading
 # --open-url
 # --skip-confirmation
 #

--- a/lib/content.rb
+++ b/lib/content.rb
@@ -21,7 +21,7 @@ module UpdateDraftRelease
     end
 
     def insert(line_num, new_lines)
-      if line_num == 0 || @lines[line_num - 1] =~ /\s/
+      if line_num == 0 || @lines[line_num - 1] =~ /^\s$/
         @lines[line_num,0] = Array(new_lines).flat_map { |line| [line, ''] }
       else
         @lines[line_num,0] = Array(new_lines).flat_map { |line| ['', line] }

--- a/lib/content.rb
+++ b/lib/content.rb
@@ -21,7 +21,7 @@ module UpdateDraftRelease
     end
 
     def insert(line_num, new_lines)
-      if line_num == 0
+      if line_num == 0 || @lines[line_num - 1] =~ /\s/
         @lines[line_num,0] = Array(new_lines).flat_map { |line| [line, ''] }
       else
         @lines[line_num,0] = Array(new_lines).flat_map { |line| ['', line] }

--- a/lib/content.rb
+++ b/lib/content.rb
@@ -21,7 +21,7 @@ module UpdateDraftRelease
     end
 
     def insert(line_num, new_lines)
-      if line_num == 0 || @lines[line_num - 1] =~ /^\s$/
+      if line_num == 0 || @lines[line_num - 1].strip.empty?
         @lines[line_num,0] = Array(new_lines).flat_map { |line| [line, ''] }
       else
         @lines[line_num,0] = Array(new_lines).flat_map { |line| ['', line] }

--- a/spec/content_spec.rb
+++ b/spec/content_spec.rb
@@ -54,26 +54,33 @@ RSpec.describe UpdateDraftRelease::Content do
   end
 
   context '#insert' do
-    subject { UpdateDraftRelease::Content.new %(line 1\nline 2\n) }
+    subject { UpdateDraftRelease::Content.new %(line 1\nline 2\n\nline 3\n) }
 
     it 'add to the beginning' do
       subject.insert(0, 'new line')
-      expect(subject.lines.size).to eq(4)
+      expect(subject.lines.size).to eq(6)
       expect(subject.lines.first).to eq('new line')
     end
 
     it 'add to any lines in between' do
       subject.insert(1, 'new line')
-      expect(subject.lines.size).to eq(4)
+      expect(subject.lines.size).to eq(6)
       expect(subject.lines[1]).to eq('')
       expect(subject.lines[2]).to eq('new line')
     end
 
-    it 'add to the end' do
+    it 'avoids double newlines' do
       subject.insert(2, 'new line')
-      expect(subject.lines.size).to eq(4)
+      expect(subject.lines.size).to eq(6)
       expect(subject.lines[2]).to eq('')
       expect(subject.lines[3]).to eq('new line')
+    end
+
+    it 'add to the end' do
+      subject.insert(3, 'new line')
+      expect(subject.lines.size).to eq(6)
+      expect(subject.lines[3]).to eq('')
+      expect(subject.lines[4]).to eq('new line')
     end
   end
 

--- a/update-draft-release.gemspec
+++ b/update-draft-release.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'update-draft-release'
-  s.version     = '0.1.4'
+  s.version     = '0.2.0'
   s.authors     = ['Wang Zhuochun']
   s.email       = 'zhuochun@hotmail.com'
 


### PR DESCRIPTION
- Update `Content` to get rid of double newlines. 
- Replace `--before-xxx` to `--in-xxx` to let it automatically insert the line into the section specified. 
- Add `--create-heading` option to create a section heading if it does not exist.
- Add `--skip-confirmation` option to skip the confirmation part (when you trust it enough :trollface:)
